### PR TITLE
Make options available

### DIFF
--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -18,6 +18,18 @@
 
 ;;; Code:
 
+(defgroup py-autopep8 nil
+  "Use autopep8 to beautify a Python buffer."
+  :group 'convenience
+  :prefix "py-autopep8-")
+
+(defcustom py-autopep8-options nil
+  "Options used for autopep8.
+
+Note that `--in-place' is used by default."
+  :group 'py-autopep8
+  :type '(repeat (string :tag "option")))
+
 (defun py-autopep8-apply-rcs-patch (patch-buffer)
   "Apply an RCS-formatted diff from PATCH-BUFFER to the current buffer."
   (let ((target-buffer (current-buffer))
@@ -77,7 +89,8 @@
     (with-current-buffer patchbuf
       (erase-buffer))
     (write-region nil nil tmpfile)
-    (if (zerop (call-process "autopep8" nil errbuf nil "--in-place" tmpfile))
+    (if (zerop (apply 'call-process "autopep8" nil errbuf nil
+                      (append `("--in-place" ,tmpfile) py-autopep8-options)))
         (if (zerop (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-" tmpfile))
             (progn
               (kill-buffer errbuf)


### PR DESCRIPTION
This commit make options available.

Usage is like this:

```
;;with aggressive level 2
(setq py-autopep8-options '("-a" "-a"))
```
