### PR TITLE
Avoid altering the kill ring

### DIFF
--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -103,7 +103,8 @@ Note that `--in-place' is used by default."
                 (goto-char (point-min))
                 (forward-line (- from line-offset 1))
                 (setq line-offset (+ line-offset len))
-                (kill-whole-line len)))
+                (kill-whole-line len)
+                (pop kill-ring)))
              (t
               (error "invalid rcs patch or internal error in py-autopep8-bf-apply--rcs-patch")))))))))
 
@@ -137,6 +138,7 @@ Note that `--in-place' is used by default."
                                         patchbuf nil "-n" "-" tmpfile))
             (progn
               (kill-buffer errbuf)
+              (pop kill-ring)
               (message (format "Buffer is already %sed" executable-name)))
 
           (if only-on-region
@@ -144,10 +146,12 @@ Note that `--in-place' is used by default."
             (py-autopep8-bf--apply-rcs-patch patchbuf))
 
           (kill-buffer errbuf)
+          (pop kill-ring)
           (message (format "Applied %s" executable-name)))
       (error (format "Could not apply %s. Check *%s Errors* for details"
                      executable-name executable-name)))
     (kill-buffer patchbuf)
+    (pop kill-ring)
     (delete-file tmpfile)))
 
 


### PR DESCRIPTION
Running py-autopep8 will alter the kill-ring leading to some unexpected side effects (for example, if buffers are set to autosave). It makes it confusing to copy a piece of text, move to another buffer and try to paste if py-autopep8 has run in-between. 

This is a bit of a naive quick fix, that simply pops the kill-ring when a kill command is issued. I think the proper way would be to use `delete-region` to replace `kill-whole-line` and `kill-buffer` usage, but my elisp is rusty and I don't know the equivalents off-hand.

This also affects py-yapf and py-isort, but I won't submit any changes unless you think the current change is sufficient or if something like `delete-region` would be cleaner.