### PR TITLE
Do not override existing before-save-hooks

### DIFF
--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -63,7 +63,7 @@ Note that `--in-place' is used by default."
 (defun py-autopep8-enable-on-save ()
   "Pre-save hook to be used before running autopep8."
   (interactive)
-  (add-hook 'before-save-hook 'py-autopep8-buffer nil t))
+  (add-hook 'before-save-hook 'py-autopep8-buffer t t))
 
 
 ;; BEGIN GENERATED -----------------


### PR DESCRIPTION
Existing hooks defined globally should probably not be overridden when autopep8's own hooks are added.

For example, I have the following globally:

(add-hook 'before-save-hook 'delete-trailing-whitespace)

but it is currently overridden. 

This PR fixes the issue.
