### PR TITLE
Allow py-autopep8 to be disabled

### DIFF
--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -60,10 +60,15 @@ Note that `--in-place' is used by default."
 
 
 ;;;###autoload
+;;; from elpa/py-autopep8/py-autopep9.el
 (defun py-autopep8-enable-on-save ()
-  "Pre-save hook to be used before running autopep8."
+  "Pre-save hook to be used before running autopep8. C-u removes this hook"
   (interactive)
-  (add-hook 'before-save-hook 'py-autopep8-buffer nil t))
+  (if current-prefix-arg
+      (progn
+        (remove-hook 'before-save-hook 'py-autopep8-buffer t)
+        (message "py-autopep8-buffer removed"))
+    (add-hook 'before-save-hook 'py-autopep8-buffer nil t)))
 
 
 ;; BEGIN GENERATED -----------------


### PR DESCRIPTION
This patch allows a user to disable py-autopep8. 

This is important when working in repositories that are not formatted according to pep8, as py-autopep8, enabled as part of a python mode hook will reformat the files in these repos.

The change adds `c-u` behavior to `py-autopep8-enable-on-save` to remove `py-autopep8-buffer` from `before-save-hook`.