### PR TITLE
Replace external temporary file with stdin/stdout usage

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,11 +20,16 @@ Use the package (available in MELPA) and add the before-save-hook to your =~/.em
 
 Now every time you save your Python file autopep8 will be executed on the current buffer.
 
-To customize the behaviour of =autopep8= you can set the =py-autopep8-options= e.g.
+** Configuration
+
+To customize the behavior of =autopep8= you can set the =py-autopep8-options= e.g.
 
 #+BEGIN_SRC lisp
 (setq py-autopep8-options '("--max-line-length=100"))
 #+END_SRC
+
+=autopep8-command=: can be used to point to the location of the =autopep8= command
+(otherwise =autopep8= from the =PATH= will be used).
 
 
 ** Functions

--- a/README.org
+++ b/README.org
@@ -1,30 +1,21 @@
-* py-autopep8.el
+* emacs py-autopep8
 
 [[https://travis-ci.org/paetzke/py-autopep8.el][https://travis-ci.org/paetzke/py-autopep8.el.svg?branch=master]]
 [[http://melpa.org/#/py-autopep8][http://melpa.org/packages/py-autopep8-badge.svg]]
 
 Provides commands, which use the external =autopep8= tool to tidy up the current buffer according to Python's PEP8.
 
-To install =autopep8= and =py-autopep8=:
+To install =autopep8=:
 
 #+BEGIN_SRC bash
 $ pip install autopep8
-$ wget https://raw.githubusercontent.com/paetzke/py-autopep8.el/master/py-autopep8.el \
-        -O /your/path/py-autopep8.el
 #+END_SRC
 
-Add the before-save-hook to your =~/.emacs=:
+Use the package (available in MELPA) and add the before-save-hook to your =~/.emacs=:
 
 #+BEGIN_SRC lisp
-(require 'py-autopep8)
+(use-package py-autopep8)
 (add-hook 'python-mode-hook 'py-autopep8-enable-on-save)
-#+END_SRC
-
-You can install =py-autopep8= also with [[https://github.com/milkypostman/melpa][MELPA]]:
-
-#+BEGIN_SRC lisp
-M-x package-install RET
-py-autopep8 RET
 #+END_SRC
 
 Now every time you save your Python file autopep8 will be executed on the current buffer.

--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -1,15 +1,21 @@
-;;; py-autopep8.el --- Use autopep8 to beautify a Python buffer
+;;; py-autopep8.el --- Use autopep8 to beautify a Python buffer -*- lexical-binding: t -*-
 
+;; Copyright (C) 2022  Campbell Barton
 ;; Copyright (C) 2013-2015, Friedrich Paetzke <f.paetzke@gmail.com>
 
 ;; Author: Friedrich Paetzke <f.paetzke@gmail.com>
+
 ;; URL: http://paetzke.me/project/py-autopep8.el
+;; Keywords: convenience
 ;; Version: 2016.1
+;; Package-Requires: ((emacs "26.1"))
 
 ;;; Commentary:
 
 ;; Provides the `py-autopep8' command, which uses the external "autopep8"
 ;; tool to tidy up the current buffer according to Python's PEP8.
+
+;;; Usage
 
 ;; To automatically apply when saving a python file, use the
 ;; following code:
@@ -25,38 +31,102 @@
 
 (defgroup py-autopep8 nil
   "Use autopep8 to beautify a Python buffer."
-  :group 'convenience
-  :prefix "py-autopep8-")
-
+  :group 'convenience)
 
 (defcustom py-autopep8-options nil
   "Options used for autopep8.
 
-Note that `--in-place' is used by default."
+Note that `-' and '--exit-code' are used by default."
   :group 'py-autopep8
   :type '(repeat (string :tag "option")))
 
 
-(defun py-autopep8--call-executable (errbuf file)
-  (zerop (apply 'call-process "autopep8" nil errbuf nil
-                (append py-autopep8-options `("--in-place", file)))))
+;; ---------------------------------------------------------------------------
+;; Internal Functions
+
+(defmacro py-autopep8--with-advice (fn-orig where fn-advice &rest body)
+  "Execute BODY with WHERE advice on FN-ORIG temporarily enabled."
+  `
+  (let ((fn-advice-var ,fn-advice))
+    (unwind-protect
+      (progn
+        (advice-add ,fn-orig ,where fn-advice-var)
+        ,@body)
+      (advice-remove ,fn-orig fn-advice-var))))
+
+(defun py-autopep8--apply-executable-to-buffer (executable-name)
+  "Formats the current buffer according to EXECUTABLE-NAME."
+  (when (not (executable-find executable-name))
+    (user-error (format "%s command not found." executable-name)))
+
+  ;; Set the default coding for the temporary buffers.
+  (let ((sentinel-called nil)
+        (command-with-args (append (list executable-name)
+                                   py-autopep8-options
+                                   (list "-" "--exit-code")))
+        (this-buffer (current-buffer))
+        (this-buffer-coding buffer-file-coding-system)
+        (stderr-buffer nil))
+
+    (with-temp-buffer
+      (setq stderr-buffer (current-buffer))
+      (with-temp-buffer
+        ;; Needed to prevent "Process .. finished" being written to
+        ;; `stderr-buffer' otherwise it's difficult to know if there was an
+        ;; error or not since an exit value of 2 may be used for invalid
+        ;; arguments as well as to check if the buffer was re-formatted.
+        (py-autopep8--with-advice
+         'internal-default-process-sentinel :override #'ignore
+
+         (let ((proc (make-process
+                      :name "autopep8-proc"
+                      :buffer (current-buffer)
+                      :coding (cons this-buffer-coding this-buffer-coding)
+                      :stderr stderr-buffer
+                      :connection-type 'pipe
+                      :command command-with-args
+                      :sentinel (lambda (_proc _msg)
+                                  (setq sentinel-called t)))))
+
+           (with-current-buffer this-buffer
+             (process-send-region proc (point-min) (point-max)))
+           (process-send-eof proc)
+
+           (while (not sentinel-called)
+             (accept-process-output))
+
+           (let ((exit-code (process-exit-status proc)))
+             (cond
+              ((eq exit-code 0)
+               ;; No difference.
+               nil)
+              ((not (and (eq exit-code 2)
+                         (zerop (buffer-size stderr-buffer))))
+               (unless (zerop (buffer-size stderr-buffer))
+                 (message "py-autopep8: error output\n%s"
+                          (with-current-buffer stderr-buffer
+                            (buffer-string))))
+               (message "py-autopep8: Command %S failed with exit code %d!"
+                           command-with-args exit-code)
+               nil)
+              (t
+               (let ((temp-buffer (current-buffer)))
+                 (with-current-buffer this-buffer
+                   (replace-buffer-contents temp-buffer)))
+
+               t)))))))))
 
 
-;;;###autoload
-(defun py-autopep8 ()
-  "Deprecated! Use py-autopep8-buffer instead."
-  (interactive)
-  (py-autopep8-buffer))
-
+;; ---------------------------------------------------------------------------
+;; Public Functions
 
 ;;;###autoload
 (defun py-autopep8-buffer ()
-  "Uses the \"autopep8\" tool to reformat the current buffer."
+  "Use the \"autopep8\" tool to reformat the current buffer."
   (interactive)
-  (py-autopep8-bf--apply-executable-to-buffer "autopep8"
-                                              'py-autopep8--call-executable
-                                              "py"))
-
+  (py-autopep8--apply-executable-to-buffer "autopep8")
+  ;; Always return nil, continue to save.
+  nil)
 
 ;;;###autoload
 (defun py-autopep8-enable-on-save ()
@@ -64,100 +134,5 @@ Note that `--in-place' is used by default."
   (interactive)
   (add-hook 'before-save-hook 'py-autopep8-buffer nil t))
 
-
-;; BEGIN GENERATED -----------------
-;; !!! This file is generated !!!
-;; buftra.el
-;; Copyright (C) 2015, Friedrich Paetzke <paetzke@fastmail.fm>
-;; Author: Friedrich Paetzke <paetzke@fastmail.fm>
-;; URL: https://github.com/paetzke/buftra.el
-;; Version: 0.5
-
-;; This code is initially copied from go-mode.el (copyright the go-mode authors).
-;; See LICENSE or https://raw.githubusercontent.com/dominikh/go-mode.el/master/LICENSE
-
-
-(defun py-autopep8-bf--apply-rcs-patch (patch-buffer)
-  "Apply an RCS-formatted diff from PATCH-BUFFER to the current buffer."
-  (let ((target-buffer (current-buffer))
-        (line-offset 0))
-    (save-excursion
-      (with-current-buffer patch-buffer
-        (goto-char (point-min))
-        (while (not (eobp))
-          (unless (looking-at "^\\([ad]\\)\\([0-9]+\\) \\([0-9]+\\)")
-            (error "invalid rcs patch or internal error in py-autopep8-bf--apply-rcs-patch"))
-          (forward-line)
-          (let ((action (match-string 1))
-                (from (string-to-number (match-string 2)))
-                (len  (string-to-number (match-string 3))))
-            (cond
-             ((equal action "a")
-              (let ((start (point)))
-                (forward-line len)
-                (let ((text (buffer-substring start (point))))
-                  (with-current-buffer target-buffer
-                    (setq line-offset (- line-offset len))
-                    (goto-char (point-min))
-                    (forward-line (- from len line-offset))
-                    (insert text)))))
-             ((equal action "d")
-              (with-current-buffer target-buffer
-                (goto-char (point-min))
-                (forward-line (- from line-offset 1))
-                (setq line-offset (+ line-offset len))
-                (kill-whole-line len)
-                (pop kill-ring)))
-             (t
-              (error "invalid rcs patch or internal error in py-autopep8-bf--apply-rcs-patch")))))))))
-
-
-(defun py-autopep8-bf--replace-region (filename)
-  (delete-region (region-beginning) (region-end))
-  (insert-file-contents filename))
-
-
-(defun py-autopep8-bf--apply-executable-to-buffer (executable-name
-                                           executable-call
-                                           file-extension)
-  "Formats the current buffer according to the executable"
-  (when (not (executable-find executable-name))
-    (error (format "%s command not found." executable-name)))
-  (let ((tmpfile (make-temp-file executable-name nil (concat "." file-extension)))
-        (patchbuf (get-buffer-create (format "*%s patch*" executable-name)))
-        (errbuf (get-buffer-create (format "*%s Errors*" executable-name)))
-        (coding-system-for-read buffer-file-coding-system)
-        (coding-system-for-write buffer-file-coding-system))
-    (with-current-buffer errbuf
-      (setq buffer-read-only nil)
-      (erase-buffer))
-    (with-current-buffer patchbuf
-      (erase-buffer))
-
-    (write-region nil nil tmpfile)
-
-    (if (funcall executable-call errbuf tmpfile)
-        (if (zerop (call-process-region (point-min) (point-max) "diff" nil
-                                        patchbuf nil "-n" "-" tmpfile))
-            (progn
-              (kill-buffer errbuf)
-              (message (format "Buffer is already %sed" executable-name)))
-
-          (py-autopep8-bf--apply-rcs-patch patchbuf)
-
-          (kill-buffer errbuf)
-          (message (format "Applied %s" executable-name)))
-      (error (format "Could not apply %s. Check *%s Errors* for details"
-                     executable-name executable-name)))
-    (kill-buffer patchbuf)
-    (delete-file tmpfile)))
-
-
-;; py-autopep8-bf.el ends here
-;; END GENERATED -------------------
-
-
 (provide 'py-autopep8)
-
-
 ;;; py-autopep8.el ends here

--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -33,13 +33,17 @@
   "Use autopep8 to beautify a Python buffer."
   :group 'convenience)
 
+(defcustom py-autopep8-command "autopep8"
+  "The location of the autopep8 command (otherwise find in PATH)."
+  :group 'py-autopep8
+  :type 'string)
+
 (defcustom py-autopep8-options nil
   "Options used for autopep8.
 
 Note that `-' and '--exit-code' are used by default."
   :group 'py-autopep8
   :type '(repeat (string :tag "option")))
-
 
 ;; ---------------------------------------------------------------------------
 ;; Internal Functions
@@ -54,14 +58,14 @@ Note that `-' and '--exit-code' are used by default."
         ,@body)
       (advice-remove ,fn-orig fn-advice-var))))
 
-(defun py-autopep8--apply-executable-to-buffer (executable-name)
-  "Formats the current buffer according to EXECUTABLE-NAME."
-  (when (not (executable-find executable-name))
-    (user-error (format "%s command not found." executable-name)))
+(defun py-autopep8--apply-executable-to-buffer ()
+  "Formats the current buffer."
+  (when (not (executable-find py-autopep8-command))
+    (user-error (format "%s command not found." py-autopep8-command)))
 
   ;; Set the default coding for the temporary buffers.
   (let ((sentinel-called nil)
-        (command-with-args (append (list executable-name)
+        (command-with-args (append (list py-autopep8-command)
                                    py-autopep8-options
                                    (list "-" "--exit-code")))
         (this-buffer (current-buffer))
@@ -129,7 +133,7 @@ Note that `-' and '--exit-code' are used by default."
 (defun py-autopep8-buffer ()
   "Use the \"autopep8\" tool to reformat the current buffer."
   (interactive)
-  (py-autopep8--apply-executable-to-buffer "autopep8")
+  (py-autopep8--apply-executable-to-buffer)
   ;; Always return nil, continue to save.
   nil)
 

--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -66,7 +66,12 @@ Note that `-' and '--exit-code' are used by default."
                                    (list "-" "--exit-code")))
         (this-buffer (current-buffer))
         (this-buffer-coding buffer-file-coding-system)
-        (stderr-buffer nil))
+        (stderr-buffer nil)
+
+        ;; Set this for `make-process' as there are no files for autopep8
+        ;; to use to detect where to read local configuration from,
+        ;; it's important the current directory is used to look this up.
+        (default-directory (file-name-directory (buffer-file-name))))
 
     (with-temp-buffer
       (setq stderr-buffer (current-buffer))

--- a/py-autopep8.el
+++ b/py-autopep8.el
@@ -55,7 +55,6 @@ Note that `--in-place' is used by default."
   (interactive)
   (py-autopep8-bf--apply-executable-to-buffer "autopep8"
                                               'py-autopep8--call-executable
-                                              nil
                                               "py"))
 
 
@@ -120,7 +119,6 @@ Note that `--in-place' is used by default."
 
 (defun py-autopep8-bf--apply-executable-to-buffer (executable-name
                                            executable-call
-                                           only-on-region
                                            file-extension)
   "Formats the current buffer according to the executable"
   (when (not (executable-find executable-name))
@@ -136,9 +134,7 @@ Note that `--in-place' is used by default."
     (with-current-buffer patchbuf
       (erase-buffer))
 
-    (if (and only-on-region (use-region-p))
-        (write-region (region-beginning) (region-end) tmpfile)
-      (write-region nil nil tmpfile))
+    (write-region nil nil tmpfile)
 
     (if (funcall executable-call errbuf tmpfile)
         (if (zerop (call-process-region (point-min) (point-max) "diff" nil
@@ -147,9 +143,7 @@ Note that `--in-place' is used by default."
               (kill-buffer errbuf)
               (message (format "Buffer is already %sed" executable-name)))
 
-          (if only-on-region
-              (py-autopep8-bf--replace-region tmpfile)
-            (py-autopep8-bf--apply-rcs-patch patchbuf))
+          (py-autopep8-bf--apply-rcs-patch patchbuf)
 
           (kill-buffer errbuf)
           (message (format "Applied %s" executable-name)))

--- a/tests.sh
+++ b/tests.sh
@@ -21,7 +21,7 @@ test_01() {
           -f write-test-file \
           -f kill-emacs
 
-    diff $TEST_FILE ./tests/01/after.py
+    diff -u $TEST_FILE ./tests/01/after.py
 }
 
 
@@ -37,7 +37,7 @@ test_02() {
           -f write-test-file \
           -f kill-emacs
 
-    diff $TEST_FILE ./tests/02/after.py
+    diff -u $TEST_FILE ./tests/02/after.py
 }
 
 
@@ -53,7 +53,7 @@ test_03() {
           -f write-test-file \
           -f kill-emacs
 
-    diff $TEST_FILE ./tests/03/after.py
+    diff -u $TEST_FILE ./tests/03/after.py
 }
 
 
@@ -68,7 +68,7 @@ test_04() {
           -f write-test-file \
           -f kill-emacs
 
-    diff $TEST_FILE ./tests/04/after.py
+    diff -u $TEST_FILE ./tests/04/after.py
 }
 
 
@@ -83,7 +83,7 @@ test_05() {
           -f write-test-file \
           -f kill-emacs
 
-    diff $TEST_FILE ./tests/05/after.py
+    diff -u $TEST_FILE ./tests/05/after.py
 }
 
 

--- a/tests/05/after.py
+++ b/tests/05/after.py
@@ -1,5 +1,4 @@
 class foo(object):
-
     def f(self):
         return 37 * -+2
 

--- a/tests/05/init.el
+++ b/tests/05/init.el
@@ -1,1 +1,2 @@
+(setq py-autopep8-options (list "--aggressive"))
 (add-hook 'python-mode-hook 'py-autopep8-enable-on-save)


### PR DESCRIPTION
- There is no longer the need to apply a diff, instead rely on
  `replace-buffer-contents` which does the diffing internally,
  avoiding the need to call an external diff command.
  _This should also support MS-Windows which may not have diff installed._
- Remove the need for a temporary file, instead handle formatting
  in memory using pipes.
- Enable lexical binding.
- Quiet warnings for checkdoc and package-lint.
- Tests now pass.
